### PR TITLE
Fix "Quit" and "About" not being translatable

### DIFF
--- a/cobang/app.py
+++ b/cobang/app.py
@@ -103,10 +103,10 @@ class CoBangApplication(Gtk.Application):
         NM.Client.new_async(None, self.cb_networkmanager_client_init_done)
 
     def setup_actions(self):
-        action_quit = Gio.SimpleAction.new(_('quit'), None)
+        action_quit = Gio.SimpleAction.new('quit', None)
         action_quit.connect('activate', self.quit_from_action)
         self.add_action(action_quit)
-        action_about = Gio.SimpleAction.new(_('about'), None)
+        action_about = Gio.SimpleAction.new('about', None)
         action_about.connect('activate', self.show_about_dialog)
         self.add_action(action_about)
 

--- a/cobang/ui.py
+++ b/cobang/ui.py
@@ -26,8 +26,8 @@ BEST_VERTICAL_HEIGHT = 654
 
 def build_app_menu_model() -> Gio.Menu:
     menu = Gio.Menu()
-    menu.append('About', 'app.about')
-    menu.append('Quit', 'app.quit')
+    menu.append(_('About'), 'app.about')
+    menu.append(_('Quit'), 'app.quit')
     return menu
 
 


### PR DESCRIPTION
Hi,

While writing the french translation for the project, I did not understand
why the "Quit" and "About" label in the hamburger menu weren't translated.
Turns out the labels weren't marked for translation, so here's that.

Kind regards,
eerielili