### PR TITLE
Fix translated *.po files for Quit/About labels

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2021-09-09 22:51+0700\n"
-"PO-Revision-Date: 2021-11-26 20:08+0100\n"
+"PO-Revision-Date: 2023-04-15 19:40+0200\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language: it\n"
 "Language-Team: it <LL@li.org>\n"
@@ -18,12 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: cobang/app.py:106
-msgid "quit"
+#: cobang/ui.py:30
+msgid "Quit"
 msgstr "Esci"
 
-#: cobang/app.py:109
-msgid "about"
+#: cobang/ui.py:29
+msgid "About"
 msgstr "Informazioni"
 
 #: cobang/app.py:542

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,14 +1,13 @@
 # Dutch translations for PROJECT.
 # Copyright (C) 2021 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
-#
+# Heimen Stoffels <vistausss@fastmail.com>, 2021.
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-09-09 17:49+0200\n"
-"PO-Revision-Date: 2021-09-09 17:51+0200\n"
+"PO-Revision-Date: 2023-04-15 19:40+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -19,12 +18,12 @@ msgstr ""
 "Generated-By: Babel 2.9.0\n"
 "X-Generator: Poedit 3.0\n"
 
-#: cobang/app.py:106
-msgid "quit"
+#: cobang/ui.py:30
+msgid "Quit"
 msgstr "Afsluiten"
 
-#: cobang/app.py:109
-msgid "about"
+#: cobang/ui.py:29
+msgid "About"
 msgstr "Over"
 
 #: cobang/app.py:542

--- a/po/tr.po
+++ b/po/tr.po
@@ -3,13 +3,12 @@
 # This file is distributed under the same license as the vn.hoabinh.quan.CoBang package
 #
 # Sabri Ünal <libreajans@gmail.com>, 2022
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: vn.hoabinh.quan.CoBang master\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-08-27 02:46+0300\n"
-"PO-Revision-Date: 2022-08-27 16:16+0300\n"
+"PO-Revision-Date: 2023-04-15 19:40+0200\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
 "Language: tr\n"
@@ -22,13 +21,13 @@ msgstr ""
 "X-Poedit-SearchPath-0: cobang\n"
 "X-Poedit-SearchPath-1: data\n"
 
-#: cobang/app.py:106
-msgid "quit"
-msgstr "çık"
+#: cobang/ui.py:30
+msgid "Quit"
+msgstr "Çık"
 
-#: cobang/app.py:109
-msgid "about"
-msgstr "hakkında"
+#: cobang/ui.py:29
+msgid "About"
+msgstr "Hakkında"
 
 #: cobang/app.py:544
 #, python-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CoBang 0.6\n"
 "Report-Msgid-Bugs-To: Nguyễn Hồng Quân <ng.hong.quan@gmail.com>\n"
 "POT-Creation-Date: 2021-09-09 22:51+0700\n"
-"PO-Revision-Date: 2020-11-17 17:31+0700\n"
+"PO-Revision-Date: 2023-04-15 19:40+0200\n"
 "Last-Translator: Nguyễn Hồng Quân <ng.hong.quan@gmail.com>\n"
 "Language: vi\n"
 "Language-Team: AgriConnect\n"
@@ -18,13 +18,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: cobang/app.py:106
-msgid "quit"
-msgstr "thoát"
+#: cobang/ui.py:30
+msgid "Quit"
+msgstr "Thoát"
 
-#: cobang/app.py:109
-msgid "about"
-msgstr "giới thiệu"
+#: cobang/ui.py:29
+msgid "About"
+msgstr "Giới thiệu"
 
 #: cobang/app.py:542
 #, python-format


### PR DESCRIPTION
Hello again,

I went ahead and did some small touches to already translated *.po files (mentioned in the LINGUAS file) to reflect changes introduced by a3b5f657828fb01adb52b97939178e4d61ba3713

No changes to the translations themselves.