### PR TITLE
appdata: Fix broken markup

### DIFF
--- a/data/vn.hoabinh.quan.CoBang.appdata.xml.in
+++ b/data/vn.hoabinh.quan.CoBang.appdata.xml.in
@@ -49,7 +49,6 @@
         <p>Fix Gschema file.</p>
       </description>
     </release>
-  <releases>
     <release version="0.10.4" date="2024-01-04" urgency="medium">
       <description translatable="no">
         <p>Upgrade Python packages for Flatpak</p>


### PR DESCRIPTION
Remove broken the `releases` tag