### PR TITLE
"mirror" in German, French, Goladian, Turkish

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -96,7 +96,7 @@ msgstr "Bild"
 
 #: data/cobang-resp.glade:419
 msgid "Mirror"
-msgstr "Mirror"
+msgstr "Spiegel"
 
 #: data/cobang-resp.glade:439
 msgid "Please choose an image file"

--- a/po/de.po
+++ b/po/de.po
@@ -96,7 +96,7 @@ msgstr "Bild"
 
 #: data/cobang-resp.glade:419
 msgid "Mirror"
-msgstr "Gương"
+msgstr "Mirror"
 
 #: data/cobang-resp.glade:439
 msgid "Please choose an image file"

--- a/po/fr.po
+++ b/po/fr.po
@@ -98,7 +98,7 @@ msgstr "Image"
 
 #: data/cobang-resp.glade:419
 msgid "Mirror"
-msgstr "Gương"
+msgstr "Miroir"
 
 #: data/cobang-resp.glade:439
 msgid "Please choose an image file"

--- a/po/nl.po
+++ b/po/nl.po
@@ -95,7 +95,7 @@ msgstr "Afbeelding"
 
 #: data/cobang-resp.glade:419
 msgid "Mirror"
-msgstr "Gương"
+msgstr "Spiegel"
 
 #: data/cobang-resp.glade:439
 msgid "Please choose an image file"

--- a/po/tr.po
+++ b/po/tr.po
@@ -98,7 +98,7 @@ msgstr "Görüntü"
 
 #: data/cobang-resp.glade:419
 msgid "Mirror"
-msgstr "Gương"
+msgstr "Ayna"
 
 #: data/cobang-resp.glade:439
 msgid "Please choose an image file"


### PR DESCRIPTION
Added translation of the word "mirror" into German, French, Goladian, Turkish.